### PR TITLE
Update defaults and idempotent loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Data is transformed from these standard formats and loaded into Elasticsearch (t
     - **-t, --transformer** *Default: transformers/[[data file basename]].js* The transformer to use. This converts state-specific data formats to our [Point Data Schema](https://github.com/cfpb/grasshopper/blob/master/docs/point_data_spec.md)
     - **-h, --host** *Default: localhost* The elasticsearch host
     - **-p, --port** *Default: 9200* The elasticsearch port
-    - **--index** *Default: address* The elasticsearch index
-    - **--type** *Default: point* The elasticsearch type
+    - **--index** *Default: state* The elasticsearch index
+    - **--type** *Default: [[resolved transformer basename]]* The elasticsearch type
     - **--profile** *Default: default* The aws credentials profile in ~/.aws/credentials. AWS keys as environment variables will override this setting.')
   - Test the loader by starting elasticsearch on localhost:9200 and running `npm test`
     - This will run the tests in test/test.js from the root of the project

--- a/grasshopper-loader.js
+++ b/grasshopper-loader.js
@@ -81,7 +81,7 @@ function processData(err, fileName, stream, cb){
     type: program.type || type  
   }
    
-  console.log("Clearing %s/%s from elasticsearch.", params.index, params.type);
+  console.log("Loading into the %s/%s elasticsearch mapping.\nWiping any preexisting data contained there.\n", params.index, params.type);
 
   esLoader.wipe(client, params.index, params.type, function(err){
     if(err){
@@ -101,6 +101,7 @@ function pipeline(params, cb){
   var transformer = params.transformer;
   var index = params.index;
   var type = params.type;
+
   var child = ogrChild(fileName, stream);
   var loader = esLoader.load(client, index, type);
 

--- a/grasshopper-loader.js
+++ b/grasshopper-loader.js
@@ -80,10 +80,17 @@ function processData(err, fileName, stream, cb){
     index: program.index,
     type: program.type || type  
   }
+   
+  console.log("Clearing %s/%s from elasticsearch.", params.index, params.type);
 
-  console.log("Streaming %s to elasticsearch.", fileName);
+  esLoader.wipe(client, params.index, params.type, function(err){
+    if(err){
+      if(cb) return cb(err);
+    }
 
-  return pipeline(params, cb);
+    console.log("Streaming %s to elasticsearch.", fileName);
+    return pipeline(params, cb);
+  })
 }
 
 

--- a/lib/checkUsage.js
+++ b/lib/checkUsage.js
@@ -52,9 +52,6 @@ module.exports = function(program){
       messages.push('Using default aws profile from ~/.aws/credentials.\n');
     }
 
-    messages.push('Loading data into ' + program.index + '.\n');
-
-
   }
 
 

--- a/lib/checkUsage.js
+++ b/lib/checkUsage.js
@@ -52,7 +52,7 @@ module.exports = function(program){
       messages.push('Using default aws profile from ~/.aws/credentials.\n');
     }
 
-    messages.push('Loading data into ' + program.index + '/' + program.type + '.\n');
+    messages.push('Loading data into ' + program.index + '.\n');
 
 
   }

--- a/lib/esLoader.js
+++ b/lib/esLoader.js
@@ -7,7 +7,8 @@ var Writable = require('readable-stream/writable');
 function writeStream(client, index, type){
   Writable.call(this);
   this.client = client;
-  this.index = index;
+  this.canonicalIndex = index;
+  this.internalIndex = Math.round(Math.random()*1e15).toString() + Math.round(Math.random()*1e15).toString();
   this.type = type;
   this.errors = [];
   this.count = 0;
@@ -20,7 +21,7 @@ util.inherits(writeStream, Writable);
 writeStream.prototype._write = function(chunk, enc, cb){
 
   this.client.bulk({
-    index: this.index,
+    index: this.internalIndex,
     type: this.type,
     body: chunk.toString()
   }, trackCount.bind(this, cb));
@@ -45,15 +46,40 @@ function connect(host, port, log){
 }
 
 
-function load(client, index, type){
-  return new writeStream(client, index, type);
+function load(client, index, type, cb){
+  var stream = new writeStream(client, index, type);
+
+  stream.on('finish', function(){
+    var self = this;
+    wipe(client, index, type, function(err){
+      if(err) cb(err);
+      client.indices.putAlias({
+        index:self.internalIndex,
+        name: self.canonicalIndex
+      }, cb.bind(self));
+    });
+  });
+
+  return stream;
 }
 
+
 function wipe(client, index, type, cb){
-  return client.indices.deleteMapping({
-           index: index,
-           type: type
-         }, cb) 
+
+  client.indices.existsAlias({name:index, type:type}, function(err, exists){
+    if(err) return cb(err);
+    if(exists){
+      client.indices.getAlias({name:index, type:type}, function(err, indexes){
+        if(err) return cb(err);
+        var indexArr = Object.keys(indexes);
+        console.log(indexArr, "deleting these");
+        client.indices.delete({index:indexArr}, cb);
+      })
+    }else{
+      console.log("NO %s/%s",index,type);
+      cb(null);
+    }
+  });
 }
 
 

--- a/lib/esLoader.js
+++ b/lib/esLoader.js
@@ -49,8 +49,16 @@ function load(client, index, type){
   return new writeStream(client, index, type);
 }
 
+function wipe(client, index, type, cb){
+  return client.indices.deleteMapping({
+           index: index,
+           type: type
+         }, cb) 
+}
+
 
 module.exports = {
   connect: connect,
-  load: load  
+  load: load,
+  wipe: wipe
 }

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,7 @@ program
   .version('0.0.1')
   .option('-h, --host <host>', 'ElasticSearch host. Defaults to localhost', 'localhost')
   .option('-p, --port <port>', 'ElasticSearch port. Defaults to 9200', Number, 9200)
-  .option('--index <index>', 'Elasticsearch index. Defaults to testind', 'testindex')
+  .option('--index <index>', 'Elasticsearch index. Defaults to testindex', 'testindex')
   .option('--type <type>', 'Elasticsearch type within the provided or default index. Defaults to testtype', 'testtype')
   .option('--profile <profile>', 'The aws credentials profile in ~/.aws/credentials. Will also respect AWS keys as environment variables.', 'default')
   .parse(process.argv);

--- a/test/test.js
+++ b/test/test.js
@@ -43,7 +43,7 @@ test('Check Usage', function(t){
       port: 9200
     },
     expected:{
-      messages:3,
+      messages:2,
       err:0
     },
     label:'data, host, port'
@@ -67,7 +67,7 @@ test('Check Usage', function(t){
       port: 9200
     },
     expected:{
-      messages:3,
+      messages:2,
       err:0
     },
     label:'Url with good filetype'
@@ -99,7 +99,7 @@ test('Check Usage', function(t){
       port: 9200
     },
     expected:{
-      messages:3,
+      messages:2,
       err:0
     },
     label:'Bucket, data, profile'
@@ -110,7 +110,7 @@ test('Check Usage', function(t){
       port: 9200
     },
     expected:{
-      messages:5,
+      messages:4,
       err:0
     },
     label:'Bucket only'
@@ -122,7 +122,7 @@ test('Check Usage', function(t){
       port: 9200
     },
     expected:{
-      messages:4,
+      messages:3,
       err:0
     },
     label:'Data, unnecessary profile'
@@ -134,7 +134,7 @@ test('Check Usage', function(t){
       port: 9200
     },
     expected:{
-      messages:5,
+      messages:4,
       err:0
     },
     label:'Bucket and transformer'


### PR DESCRIPTION
Since it seems we will now have an index/type mapping for every file, it made sense to make loading idempotent. It currently achieves this by deleting the resolved mapping and reloading the data.

This removes the ability to implement a versioning scheme per data load, but also removes the necessity to deduplicate data, which would be messy/error-prone without ids if we're assuming data can be updated by states arbitrarily. As such, this PR closes #13.