### PR TITLE
Add support for a layerName key in the metadata file

### DIFF
--- a/lib/ogrChild.js
+++ b/lib/ogrChild.js
@@ -2,20 +2,23 @@
 var spawn = require('child_process').spawn;
 var pump = require('pump');
 
-module.exports = function(file, stream, s_srs){
+module.exports = function(file, stream, record){
   var child;
+  if(!record) record = {};
   var args = ['-f', 'GeoJson', '-t_srs', 'WGS84', '/vsistdout/'];
 
-  if(s_srs){
-    args.splice(4, 0, '-s_srs', s_srs);
+  if(record.spatialReference){
+    args.splice(4, 0, '-s_srs', record.spatialReference);
   }
 
   if(stream){
     args.push('/vsistdin/');
+    if(record.layerName) args.push(record.layerName);
     child = spawn('ogr2ogr', args);
     pump(stream, child.stdin);
   }else{
     args.push(file);
+    if(record.layerName) args.push(record.layerName);
     child = spawn('ogr2ogr', args);
   }
 

--- a/lib/retriever-pipeline.js
+++ b/lib/retriever-pipeline.js
@@ -6,7 +6,7 @@ var ogrChild = require('./ogrChild');
 
 function retrieverPipeline(record, file, stream){
 
-    var jsonChild = ogrChild(file, stream, record.spatialReference);
+    var jsonChild = ogrChild(file, stream, record);
     var centroids = centroidStream.stringify();
 
     jsonChild.stderr.on('data', function(errorText){


### PR DESCRIPTION
When multiple feature classes are contained in one file geodatabase, ogr2ogr can't auto convert to GeoJSON (also, loader can't divine which feature class you're actually interested in). This fixes that by allowing the specification of a `layerName` in the metadata file.