### PR TITLE
Add the ability to provide a separator to 'multi' metadata objects

### DIFF
--- a/lib/resolveFields.js
+++ b/lib/resolveFields.js
@@ -1,3 +1,16 @@
+function joinWithSeparators(parts, separators){
+  var val = '';
+  if(!separators) separators = {}
+
+  parts.forEach(function(v, i){
+    var defaultSep = i===0 ? '' : ' ';
+    val += (separators[i] === undefined ? defaultSep : separators[i]) + v;
+  })
+
+  if(separators[parts.length] !== undefined) val+=separators[parts.length];
+
+  return val
+}
 
 module.exports = function(props, fields){
   var vals = {};
@@ -17,7 +30,7 @@ module.exports = function(props, fields){
     if(field.type === 'dynamic'){
       val = new Function('props', field.value)(props); //eslint-disable-line
     }else if(field.type === 'multi'){
-      val = field.value.map(mapProps).filter(truthy).join(' ');
+      val = joinWithSeparators(field.value.map(mapProps).filter(truthy), field.separators)
     }else{
       val = props[field.value];
     }

--- a/test/data/metadata/ncmetaSep.json
+++ b/test/data/metadata/ncmetaSep.json
@@ -1,0 +1,29 @@
+{
+    "name": "north_carolina",
+    "url": "http://data.nconemap.gov/downloads/vector/mastadd14.zip",
+    "file": "AddressNC_2014.gdb",
+    "spatialReference": "EPSG:2264",
+    "fields": {
+      "Number": {
+        "type": "static",
+        "value": "ADDR_HN"
+      },
+      "Street": {
+        "type": "multi",
+        "value": ["ADDR_SN", "ADDR_ST"],
+        "separators": {"1":"SEPARATOR"}
+      },
+      "City": {
+        "type": "static",
+        "value": "PO_NAME"
+      },
+      "State": {
+        "type": "static",
+        "value": "STATE"
+      },
+      "Zip": {
+        "type": "static",
+        "value": "ZIPCODE"
+      }
+    }
+  }

--- a/test/test.js
+++ b/test/test.js
@@ -475,15 +475,20 @@ test('ftpWrapper addendum', function(t){
 
 
 test('resolveFields module', function(t){
-  t.plan(4);
+  t.plan(6);
 
   var ncmeta = fs.readJsonSync('test/data/metadata/ncmeta.json');
+  var ncsep = fs.readJsonSync('test/data/metadata/ncmetaSep.json');
   var nc = fs.readJsonSync('test/data/fields/north_carolina.json');
 
   var resolved = resolveFields(nc.properties, ncmeta.fields);
+  var resolvedWithSep = resolveFields(nc.properties, ncsep.fields);
 
+  t.equal(resolved.Street, 'CENTER STAGE COURT', 'Resolves and joins street');
   t.equal(resolved.State, 'NC', 'Resolves state');
   t.equal(resolved.Zip, '27127', 'Resolves zip');
+
+  t.equal(resolvedWithSep.Street, 'CENTER STAGESEPARATORCOURT', 'Resolves street with separator');
 
   try{
     resolveFields(nc.properties, {});


### PR DESCRIPTION
Closes #195

Providing an object as the `separators` key to a `multi` labeled field will allow the introduction of separators. This also allows prefixing and suffixing of the `multi` array.

The form of the object is `{ "1": "firstsep", "3": "thirdsep"}`

If the `multi` value was `["fieldname0","fieldname1","fieldname2"]` which resolves to, say, `zero one two` normally, with the above `separators` key we'd get `zerofirstsepone twothirdsep`. You can see that the separators index starts BEFORE the first item (where the prefix would go) and ends AFTER the last item which is how we injected `thirdsep`). This means there will always be one more separator possible than the number of fields in a `multi`

Cheers @kgudel
