### PR TITLE
Provide isZipped flag to force unzipping

### DIFF
--- a/lib/retriever.js
+++ b/lib/retriever.js
@@ -157,7 +157,7 @@ function retrieve(options, callback){
       output.overridden.push(record.name);
     }
 
-    if(zipReg.test(record._override) || zipReg.test(record.url)){
+    if(record.isZipped || zipReg.test(record._override) || zipReg.test(record.url)){
       logger.info('Unzipping file stream of %s from %s', record.name, record._override || record.url);
       handleZip(stream, record, scratchSpace, handleStream, handleError);
     }else{


### PR DESCRIPTION
Allows loader to work when files are zipped but aren't referenced directly (ie no `.zip` extension)